### PR TITLE
rename ModalWrapper

### DIFF
--- a/AiForms.Maui.Dialogs/Platforms/iOS/DisposeHelpers.cs
+++ b/AiForms.Maui.Dialogs/Platforms/iOS/DisposeHelpers.cs
@@ -5,7 +5,7 @@ namespace AiForms.Dialogs.iOS;
 
 public static class DisposeHelpers
 {
-    public static Type ModalWrapper = typeof(Element).Assembly.GetType("Microsoft.Maui.Controls.Platform.ModalWrapper");
+    public static Type ModalWrapper = typeof(Element).Assembly.GetType("Microsoft.Maui.Controls.Platform.ControlsModalWrapper");
     public static MethodInfo ModalWrapperDispose = ModalWrapper.GetMethod("Dispose");
     public static MethodInfo ElementDescendants = typeof(Element).GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance).FirstOrDefault(x => x.Name == "Descendants" && !x.IsGenericMethod);    
 


### PR DESCRIPTION
The name of ModalWrapper had been changed.
https://github.com/dotnet/maui/commits/d9eedd6acd221e971e97cf6fc8af3d4271cf5440/src/Controls/src/Core/Platform/iOS/ControlsModalWrapper.cs