### PR TITLE
fix(crash): ReusableDialog/Loading の Dispose で NullReferenceException を防止

### DIFF
--- a/AiForms.Maui.Dialogs/Dialog/ReusableDialog.Android.cs
+++ b/AiForms.Maui.Dialogs/Dialog/ReusableDialog.Android.cs
@@ -238,24 +238,31 @@ public class ReusableDialog : Java.Lang.Object, IReusableDialog
     {
         if (disposing)
         {
-            _dlgView.Destroy();
-            if(_dlgView.BindingContext is IDialogViewModelDestroy vm)
+            // _dlgView が null の場合は既に Dispose 済み、または初期化されていない
+            if (_dlgView != null)
             {
-                vm.Destroy();
+                _dlgView.Destroy();
+                if(_dlgView.BindingContext is IDialogViewModelDestroy vm)
+                {
+                    vm.Destroy();
+                }
+                _dlgView.LayoutNative = null;
+                _dlgView.BindingContext = null;
+                _dlgView.Parent = null;
+                _dlgView.Handler = null;
+                _dlgView = null;
             }
-            _dlgView.LayoutNative = null;
-            _dlgView.BindingContext = null;
-            _dlgView.Parent = null;
-            _dlgView.Handler = null;
-            _dlgView = null;
 
-            _contentView.Touch -= _contentView_Touch;
+            // _contentView が null の場合は Initialize() が未実行
+            if (_contentView != null)
+            {
+                _contentView.Touch -= _contentView_Touch;
+                _contentView.Dispose();
+                _contentView = null;
+            }
 
             _container?.Dispose();
             _container = null;
-            
-            _contentView.Dispose();
-            _contentView = null;
 
             _handler = null;
 

--- a/AiForms.Maui.Dialogs/Dialog/ReusableDialog.iOS.cs
+++ b/AiForms.Maui.Dialogs/Dialog/ReusableDialog.iOS.cs
@@ -78,35 +78,58 @@ public class ReusableDialog: IReusableDialog
 
     public void Dispose()
     {
-        _dlgView.Destroy();
-        if(_dlgView.BindingContext is IDialogViewModelDestroy vm)
+        // _dlgView が null の場合は既に Dispose 済み、または初期化されていない
+        if (_dlgView != null)
         {
-            vm.Destroy();
+            _dlgView.Destroy();
+            if(_dlgView.BindingContext is IDialogViewModelDestroy vm)
+            {
+                vm.Destroy();
+            }
+            _dlgView.Parent = null;
+            _dlgView.DisposeModalAndChildHandlers();
+            _dlgView.BindingContext = null;
+            _dlgView.Handler = null;
+            _dlgView = null;
         }
-        _dlgView.Parent = null;
-        _dlgView.DisposeModalAndChildHandlers();
-        _dlgView.BindingContext = null;
-        _dlgView.Handler = null;
-        _dlgView = null;
 
-        var tapGesture = _overlayView.GestureRecognizers.FirstOrDefault();
-        _overlayView.RemoveGestureRecognizer(tapGesture);
-        tapGesture?.Dispose();
+        // _overlayView はコンストラクタで作成されるため通常は null ではないが、安全のためチェック
+        if (_overlayView != null)
+        {
+            var tapGesture = _overlayView.GestureRecognizers?.FirstOrDefault();
+            if (tapGesture != null)
+            {
+                _overlayView.RemoveGestureRecognizer(tapGesture);
+                tapGesture.Dispose();
+            }
 
-        _overlayView.RemoveFromSuperview();
-        _overlayView.Dispose();
-        _overlayView = null;
+            _overlayView.RemoveFromSuperview();
+            _overlayView.Dispose();
+            _overlayView = null;
+        }
 
-        _contentViewController.TransitioningDelegate = null;
-        _contentViewController.Dispose();
-        _contentViewController = null;
+        // _contentViewController は Initialize() で作成されるため null の可能性がある
+        if (_contentViewController != null)
+        {
+            _contentViewController.TransitioningDelegate = null;
+            _contentViewController.Dispose();
+            _contentViewController = null;
+        }
 
-        _dialogController.Dispose();
-        _dialogController = null;
+        // _dialogController は Initialize() で作成されるため null の可能性がある
+        if (_dialogController != null)
+        {
+            _dialogController.Dispose();
+            _dialogController = null;
+        }
 
-        _handler.PlatformView?.RemoveFromSuperview();
-        _handler.DisconnectHandler();
-        _handler = null;
+        // _handler は Initialize() で作成されるため null の可能性がある
+        if (_handler != null)
+        {
+            _handler.PlatformView?.RemoveFromSuperview();
+            _handler.DisconnectHandler();
+            _handler = null;
+        }
     }
 
     public async Task<bool> ShowAsync()

--- a/AiForms.Maui.Dialogs/Loading/LoadingBase.Android.cs
+++ b/AiForms.Maui.Dialogs/Loading/LoadingBase.Android.cs
@@ -38,9 +38,13 @@ public class LoadingBase:IDisposable
     {
         MainThread.BeginInvokeOnMainThread(() =>
         {
-            ContentView.RemoveFromParent();
-            ContentView.Dispose();
-            ContentView = null;
+            // ContentView が null の場合は既に Dispose 済み
+            if (ContentView != null)
+            {
+                ContentView.RemoveFromParent();
+                ContentView.Dispose();
+                ContentView = null;
+            }
         });
 
         OnceInitializeAction = null;

--- a/AiForms.Maui.Dialogs/Loading/LoadingBase.iOS.cs
+++ b/AiForms.Maui.Dialogs/Loading/LoadingBase.iOS.cs
@@ -26,13 +26,19 @@ public class LoadingBase:IDisposable
 
     public virtual void Dispose()
     {
-        NSLayoutConstraint.DeactivateConstraints(_overlayConstraints.ToArray());
-        _overlayConstraints.Clear();
-        _overlayConstraints = null;
+        if (_overlayConstraints != null)
+        {
+            NSLayoutConstraint.DeactivateConstraints(_overlayConstraints.ToArray());
+            _overlayConstraints.Clear();
+            _overlayConstraints = null;
+        }
 
-        OverlayView.RemoveFromSuperview();
-        OverlayView.Dispose();
-        OverlayView = null;
+        if (OverlayView != null)
+        {
+            OverlayView.RemoveFromSuperview();
+            OverlayView.Dispose();
+            OverlayView = null;
+        }
 
         Progress = null;
         IsCurrentScope = null;

--- a/AiForms.Maui.Dialogs/Loading/ReusableLoading.Android.cs
+++ b/AiForms.Maui.Dialogs/Loading/ReusableLoading.Android.cs
@@ -28,10 +28,14 @@ public class ReusableLoading: LoadingBase,IReusableLoading
 
     public override void Dispose()
     {
-        _loadingView.Destroy();
-        _loadingView.BindingContext = null;
-        _loadingView.Parent = null;
-        _loadingView = null;
+        // _loadingView が null の場合は既に Dispose 済み
+        if (_loadingView != null)
+        {
+            _loadingView.Destroy();
+            _loadingView.BindingContext = null;
+            _loadingView.Parent = null;
+            _loadingView = null;
+        }
 
         if (_handler != null)
         {            

--- a/AiForms.Maui.Dialogs/Loading/ReusableLoading.iOS.cs
+++ b/AiForms.Maui.Dialogs/Loading/ReusableLoading.iOS.cs
@@ -23,14 +23,22 @@ public class ReusableLoading: LoadingBase,IReusableLoading
 
     public override void Dispose()
     {
-        _loadingView.Parent = null;
-        _loadingView.DisposeModalAndChildHandlers();
-        _handler.DisconnectHandler();
-        _handler = null;
-    
-        _loadingView.Destroy();
-        _loadingView.BindingContext = null;
-        _loadingView = null;
+        // _loadingView が null の場合は既に Dispose 済み
+        if (_loadingView != null)
+        {
+            _loadingView.Parent = null;
+            _loadingView.DisposeModalAndChildHandlers();
+            _loadingView.Destroy();
+            _loadingView.BindingContext = null;
+            _loadingView = null;
+        }
+
+        // _handler は Initialize() で作成されるため null の可能性がある
+        if (_handler != null)
+        {
+            _handler.DisconnectHandler();
+            _handler = null;
+        }
 
         base.Dispose();
     }


### PR DESCRIPTION
## クラッシュ修正

### クラッシュ情報
- **タイトル**: AiForms.Dialogs.ReusableDialog.Dispose + 0x62
- **サブタイトル**: android.runtime.JavaProxyThrowable - [System.NullReferenceException]: Object reference not set to an instance of an object
- **発生件数**: 1
- **プラットフォーム**: android
- **アプリバージョン**: 3.0.7

### 根本原因
`ReusableDialog.Dispose` メソッドで、`Initialize()` が呼ばれる前（つまり `ShowAsync()` が一度も呼ばれていない状態）に `Dispose()` が呼ばれると、未初期化のフィールド（`_contentView`, `_handler` など）にアクセスして `NullReferenceException` が発生していた。

### 修正内容
Dispose メソッド内で、各フィールドに対して null チェックを追加し、未初期化のフィールドへのアクセスを防止しました。

### 変更ファイル
- `ReusableDialog.Android.cs` - `_dlgView`, `_contentView` の null チェック追加
- `ReusableDialog.iOS.cs` - `_dlgView`, `_overlayView`, `_contentViewController`, `_dialogController`, `_handler` の null チェック追加
- `ReusableLoading.iOS.cs` - `_loadingView`, `_handler` の null チェック追加
- `LoadingBase.iOS.cs` - `_overlayConstraints`, `OverlayView` の null チェック追加
- `ReusableLoading.Android.cs` - `_loadingView` の null チェック追加
- `LoadingBase.Android.cs` - `ContentView` の null チェック追加

### 同一パターンの対応
全ての Reusable 系コンポーネント（Dialog および Loading）の Dispose メソッドに同様の null チェックを実装済み。

### テスト
- 各プラットフォーム（Android/iOS）で Dispose メソッドの null チェックが正しく動作することを確認
- 未初期化状態での Dispose 呼び出しでクラッシュが発生しないことを確認