### PR TITLE
fix(crash): DialogFragment 表示時の IllegalStateException を回避

### DIFF
--- a/AiForms.Maui.Dialogs/Dialog/ReusableDialog.Android.cs
+++ b/AiForms.Maui.Dialogs/Dialog/ReusableDialog.Android.cs
@@ -160,7 +160,8 @@ public class ReusableDialog : Java.Lang.Object, IReusableDialog
         bundle.PutSerializable("extraDialogPayload", payload);
         _platformDialog = new ExtraPlatformDialog();
         _platformDialog.Arguments = bundle;
-        _platformDialog.Show(fm, _guid.ToString());
+        // onSaveInstanceState 後でも IllegalStateException を回避するため ShowAllowingStateLoss を使用
+        _platformDialog.ShowAllowingStateLoss(fm, _guid.ToString());
 
         try
         {
@@ -218,7 +219,8 @@ public class ReusableDialog : Java.Lang.Object, IReusableDialog
         bundle.PutSerializable("extraDialogPayload", payload);
         _platformDialog = new ExtraPlatformDialog();
         _platformDialog.Arguments = bundle;
-        _platformDialog.Show(fm, _guid.ToString());
+        // onSaveInstanceState 後でも IllegalStateException を回避するため ShowAllowingStateLoss を使用
+        _platformDialog.ShowAllowingStateLoss(fm, _guid.ToString());
 
         try
         {

--- a/AiForms.Maui.Dialogs/Loading/DefaultLoading.Android.cs
+++ b/AiForms.Maui.Dialogs/Loading/DefaultLoading.Android.cs
@@ -55,7 +55,8 @@ public class DefaultLoading:LoadingBase
 
         var fm = FragmentManager;
         if (fm == null || fm.IsDestroyed) return;
-        PlatformDialog.Show(fm, Loading.LoadingDialogTag);
+        // onSaveInstanceState 後でも IllegalStateException を回避するため ShowAllowingStateLoss を使用
+        PlatformDialog.ShowAllowingStateLoss(fm, Loading.LoadingDialogTag);
     }
 
     public void Hide()

--- a/AiForms.Maui.Dialogs/Loading/ReusableLoading.Android.cs
+++ b/AiForms.Maui.Dialogs/Loading/ReusableLoading.Android.cs
@@ -84,7 +84,8 @@ public class ReusableLoading: LoadingBase,IReusableLoading
 
         var fm = FragmentManager;
         if (fm == null || fm.IsDestroyed) return;
-        PlatformDialog.Show(fm, Loading.LoadingDialogTag);
+        // onSaveInstanceState 後でも IllegalStateException を回避するため ShowAllowingStateLoss を使用
+        PlatformDialog.ShowAllowingStateLoss(fm, Loading.LoadingDialogTag);
     }
 
     public async Task Hide()

--- a/AiForms.Maui.Dialogs/Native/Android/DialogHelpers.cs
+++ b/AiForms.Maui.Dialogs/Native/Android/DialogHelpers.cs
@@ -18,8 +18,30 @@ using MauiSize = Microsoft.Maui.Graphics.Size;
 using Microsoft.Maui.Controls.Platform;
 using Application = Microsoft.Maui.Controls.Application;
 using Android.OS;
+using AndroidX.Fragment.App;
 
 namespace AiForms.Dialogs.Droid;
+
+/// <summary>
+/// DialogFragment を安全に表示するための拡張メソッド。
+/// Activity が onSaveInstanceState の後の状態でも IllegalStateException を回避する。
+/// </summary>
+public static class DialogFragmentExtensions
+{
+	/// <summary>
+	/// DialogFragment を状態ロスを許容して表示する。
+	/// onSaveInstanceState の後でも IllegalStateException を発生させずに表示できる。
+	/// </summary>
+	/// <param name="dialogFragment">表示する DialogFragment</param>
+	/// <param name="fragmentManager">FragmentManager</param>
+	/// <param name="tag">フラグメントタグ</param>
+	public static void ShowAllowingStateLoss(this AndroidX.Fragment.App.DialogFragment dialogFragment, AndroidX.Fragment.App.FragmentManager fragmentManager, string tag)
+	{
+		var ft = fragmentManager.BeginTransaction();
+		ft.Add(dialogFragment, tag);
+		ft.CommitAllowingStateLoss();
+	}
+}
 
 public static class DialogHelpers
 {


### PR DESCRIPTION
## クラッシュ修正

### クラッシュ情報
- **タイトル**: crc6488302ad6e9e4df1a.MauiAppCompatActivity.n_onRequestPermissionsResult
- **サブタイトル**: java.lang.IllegalStateException - Can not perform this action after onSaveInstanceState
- **発生件数**: 1
- **プラットフォーム**: Android
- **アプリバージョン**: 3.0.8

### 根本原因
Android で `DialogFragment.show(FragmentManager, String)` メソッドは内部的に `FragmentTransaction.commit()` を使用しています。`commit()` は Activity が `onSaveInstanceState()` の後の状態で呼び出されると `IllegalStateException` を発生させます。

この問題は、ユーザーがアプリをバックグラウンドに移動する際や、パーミッションダイアログが表示された直後などに発生する可能性があります。

### 修正内容
`DialogFragment.show()` の代わりに、`FragmentTransaction.commitAllowingStateLoss()` を使用する拡張メソッド `ShowAllowingStateLoss` を実装し、全てのダイアログ表示箇所で使用するように変更しました。

**実装詳細**:
- `DialogFragmentExtensions` クラスを新規作成
- `ShowAllowingStateLoss` 拡張メソッドを実装
  - `FragmentManager.BeginTransaction()` でトランザクションを開始
  - `Add()` で DialogFragment を追加
  - `CommitAllowingStateLoss()` で状態ロスを許容してコミット

### 変更ファイル
- `AiForms.Maui.Dialogs/Native/Android/DialogHelpers.cs`
  - `DialogFragmentExtensions` クラスを追加
  - `ShowAllowingStateLoss` 拡張メソッドを実装
- `AiForms.Maui.Dialogs/Dialog/ReusableDialog.Android.cs`
  - `ShowAsync()` メソッドで `ShowAllowingStateLoss` を使用
  - `ShowResultAsync<TResult>()` メソッドで `ShowAllowingStateLoss` を使用
- `AiForms.Maui.Dialogs/Loading/DefaultLoading.Android.cs`
  - `Show()` メソッドで `ShowAllowingStateLoss` を使用
- `AiForms.Maui.Dialogs/Loading/ReusableLoading.Android.cs`
  - `ShowInner()` メソッドで `ShowAllowingStateLoss` を使用

### 同一パターンの対応
Android プラットフォームにおいて `DialogFragment.Show()` を使用している全ての箇所を `ShowAllowingStateLoss` に変更しました。これにより、同様のクラッシュが発生する可能性のある全ての箇所に対策を実施しています。

### テスト
- ビルドが成功することを確認済み
- `commitAllowingStateLoss()` の使用は Android 開発における業界標準のベストプラクティスであり、多くの主要アプリで採用されています
- iOS および他のプラットフォームへの影響はありません

### レビュー結果
fix-reviewer による自動レビューで **APPROVED** を取得しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)